### PR TITLE
Ensure mid-build cleanups cancel and cleanup partial work

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -2,12 +2,14 @@ var RSVP = require('rsvp')
 var mapSeries = require('promise-map-series')
 var apiCompat = require('./api_compat')
 var heimdall = require('heimdalljs');
-
+var SilentError = require('silent-error');
 
 exports.Builder = Builder
 function Builder (tree) {
   this.tree = tree
   this.allTreesRead = [] // across all builds
+  this._currentStep = undefined;
+  this.canceled = false;
 }
 
 function wrapStringErrors(reason) {
@@ -32,19 +34,29 @@ function summarize(node) {
 RSVP.EventTarget.mixin(Builder.prototype)
 
 Builder.prototype.build = function (willReadStringTree) {
+  if (this.canceled) {
+    return RSVP.Promise.reject(new Error('cannot build this builder, as it has been previously canceled'));
+  }
   var builder = this
 
   var newTreesRead = []
   var nodeCache = []
   var hasMergedInstantiationStack = false;
 
-  return RSVP.Promise.resolve()
+  this._currentStep = RSVP.Promise.resolve()
     .then(function () {
       return readAndReturnNodeFor(builder.tree) // call builder.tree.read()
     })
     .then(summarize)
     .finally(appendNewTreesRead)
+    .finally(unsetCurrentStep)
     .catch(wrapStringErrors)
+
+  return this._currentStep;
+
+  function unsetCurrentStep() {
+    builder._currentStep = null
+  }
 
 
   function appendNewTreesRead() {
@@ -58,6 +70,13 @@ Builder.prototype.build = function (willReadStringTree) {
   // Read the `tree` and return its node, which in particular contains the
   // tree's output directory (node.directory)
   function readAndReturnNodeFor (tree) {
+    if (builder.canceled) {
+      var canceled = new SilentError('Build Canceled');
+      canceled.wasCanceled = true
+      return RSVP.Promise.reject(canceled);
+    }
+
+
     builder.warnIfNecessary(tree)
     tree = builder.wrapIfNecessary(tree)
     var index = newTreesRead.indexOf(tree)
@@ -118,6 +137,9 @@ Builder.prototype.build = function (willReadStringTree) {
               })
           })
         }).catch(function(e) {
+          if (typeof e === 'object' && e !== null && e.isSilentError) {
+            throw e;
+          }
           if (!hasMergedInstantiationStack) {
             e.stack = e.stack +  '\n\nThe broccoli plugin was instantiated at: \n' + tree._instantiationStack + '\n\n'
             e.message = 'The Broccoli Plugin: ' + tree + ' failed with:'
@@ -151,8 +173,24 @@ function cleanupTree(tree) {
   }
 }
 
+Builder.prototype._cancel = function () {
+  this.canceled = true;
+  return this._currentStep || RSVP.Promise.resolve();
+};
+
 Builder.prototype.cleanup = function () {
-  return mapSeries(this.allTreesRead, cleanupTree)
+  var builder = this;
+
+  return this._cancel().finally(function() {
+    return mapSeries(builder.allTreesRead, cleanupTree)
+  }).catch(function(e) {
+    if (typeof e === 'object' && e !== null && e.wasCanceled) {
+      // if the exception is that we canceled, then cancellation was
+      // non-exceptional and we can safely recover
+    } else {
+      throw e;
+    }
+  });
 }
 
 Builder.prototype.wrapIfNecessary = function (tree) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "promise-map-series": "^0.2.1",
     "quick-temp": "^0.1.2",
     "rimraf": "^2.2.8",
-    "rsvp": "^3.0.17"
+    "rsvp": "^3.0.17",
+    "silent-error": "^1.0.1"
   },
   "devDependencies": {
     "tap": "^0.4.8"


### PR DESCRIPTION
this doesn't cleanup anything in plugin constructors, but will cleanup tmp directories created by broccoli for the associated plugins.

Future work should likely ensure all plugins considered by a build, and invoke cleanup on them. in 0.18.x though, we only discover plugins as we build the graph.

This is sufficient to fix the bug I set out to fix, but may requires changes in the future to address the above identified issues.

- [x] make work (test in real situations)
- [x] write tests to confirm it works
- [x] POC for upstream: https://github.com/broccolijs/broccoli/pull/312
- [x] 👀 