### PR TITLE
[BUGFIX nice-thing] expose old events for compat

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -45,11 +45,17 @@ Builder.prototype.build = function (willReadStringTree) {
 
   this._currentStep = RSVP.Promise.resolve()
     .then(function () {
+      // added for backwards compat. Can be safely removed for 1.0.0
+      builder.trigger('start');
       return readAndReturnNodeFor(builder.tree) // call builder.tree.read()
     })
     .then(summarize)
     .finally(appendNewTreesRead)
     .finally(unsetCurrentStep)
+    .finally(function() {
+      // added for backwards compat. Can be safely removed for 1.0.0
+      builder.trigger('end');
+    })
     .catch(wrapStringErrors)
 
   return this._currentStep;

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -292,5 +292,32 @@ test('Builder', function (t) {
     })
   })
 
+  test('start/stop events', function (t) {
+    // Can be removed in 1.0.0
+    var builder = new Builder('fooDir')
+    var startWasCalled = 0;
+    var  stopWasCalled = 0;
+    builder.on('start', function() {
+      startWasCalled++;
+    });
+
+    builder.on('end', function() {
+      stopWasCalled++;
+    });
+
+    t.equal(startWasCalled, 0);
+    t.equal(stopWasCalled, 0);
+
+    builder.build(function willReadStringTree (dir) {
+      t.equal(startWasCalled, 1);
+      t.equal(stopWasCalled, 0);
+      t.equal(dir, 'fooDir')
+    }).finally(function() {
+      t.equal(startWasCalled, 1);
+      t.equal(stopWasCalled, 1);
+      t.end()
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
Turns out, some people relied on this intimidate API. For those, we should restore it.

- [x] restore `builder.on('start'` and  `builder.on('end`
- [x] tests
- [x] r?