### PR TITLE
Ensure heimdall is also aware of Cached Broccoli nodes

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -94,14 +94,24 @@ Builder.prototype.build = function (willReadStringTree) {
         // incomplete node. This can happen if there is a cycle.
         throw new Error('Tree cycle detected')
       }
-      return RSVP.Promise.resolve(nodeCache[index])
+      var cachedNode = nodeCache[index];
+
+      heimdall.start({
+        name: getDescription(cachedNode.tree),
+        broccoliNode: true,
+        broccoliId: cachedNode.id,
+        broccoliCachedNode: true
+      }).stop();
+
+      return RSVP.Promise.resolve(cachedNode)
     }
 
     var node = new Node(tree);
     var cookie = heimdall.start({
       name: getDescription(tree),
       broccoliNode: true,
-      broccoliId: node.id
+      broccoliId: node.id,
+      broccoliCachedNode: false
     });
 
     node.__heimdall__ = heimdall.current;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -97,12 +97,14 @@ Builder.prototype.build = function (willReadStringTree) {
       return RSVP.Promise.resolve(nodeCache[index])
     }
 
+    var node = new Node(tree);
     var cookie = heimdall.start({
       name: getDescription(tree),
       broccoliNode: true,
+      broccoliId: node.id
     });
 
-    var node = new Node(tree, heimdall.current)
+    node.__heimdall__ = heimdall.current;
     // better to use promises via heimdall.node(description, fn)
 
     // we don't actually support duplicate trees, as such we should likely tag them..

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -175,19 +175,29 @@ test('Builder', function (t) {
   test('tree graph', function (t) {
     var parent = countingTree(function (readTree) {
       return readTree(child).then(function (dir) {
-        return new RSVP.Promise(function (resolve, reject) {
-          setTimeout(function() { resolve('parentTreeDir') }, 30)
+        return readTree(shared).then(function() {
+          return new RSVP.Promise(function (resolve, reject) {
+            setTimeout(function() { resolve('parentTreeDir') }, 30)
+          })
         })
       })
     }, 'parent')
 
     var child = countingTree(function (readTree) {
-      return readTree('srcDir').then(function (dir) {
+      return readTree(shared).then(function (dir) {
         return new RSVP.Promise(function (resolve, reject) {
           setTimeout(function() { resolve('childTreeDir') }, 20)
         })
       })
     }, 'child')
+
+    var shared = countingTree(function (readTree) {
+      return readTree('srcDir').then(function (dir) {
+        return new RSVP.Promise(function (resolve, reject) {
+          setTimeout(function() { resolve('sharedTreeDir') }, 20)
+        })
+      })
+    }, 'shared')
 
     var timeEqual = function (a, b) {
       t.equal(typeof a, 'number')
@@ -206,20 +216,21 @@ test('Builder', function (t) {
       var parentBroccoliNode = hash.graph
       t.equal(parentBroccoliNode.directory, 'parentTreeDir')
       t.equal(parentBroccoliNode.tree, parent)
-      t.equal(parentBroccoliNode.subtrees.length, 1)
+      t.equal(parentBroccoliNode.subtrees.length, 2)
       var childBroccoliNode = parentBroccoliNode.subtrees[0]
       t.equal(childBroccoliNode.directory, 'childTreeDir')
       t.equal(childBroccoliNode.tree, child)
       t.equal(childBroccoliNode.subtrees.length, 1)
-      var leafBroccoliNode = childBroccoliNode.subtrees[0]
+      var sharedBroccoliNode = childBroccoliNode.subtrees[0]
+      t.equal(sharedBroccoliNode.subtrees.length, 1)
+      var leafBroccoliNode = sharedBroccoliNode.subtrees[0]
       t.equal(leafBroccoliNode.directory, 'srcDir')
       t.equal(leafBroccoliNode.tree, 'srcDir')
       t.equal(leafBroccoliNode.subtrees.length, 0)
 
-
       var json = heimdall.toJSON()
 
-      t.equal(json.nodes.length, 4)
+      t.equal(json.nodes.length, 6)
 
       var parentNode = json.nodes[1]
       timeEqual(parentNode.stats.time.self, 30e6)
@@ -250,19 +261,21 @@ test('Builder', function (t) {
           id: {
             name: 'parent',
             broccoliNode: true,
-            broccoliId: 0
+            broccoliId: 0,
+            broccoliCachedNode: false
           },
           stats: {
             own: {},
             time: {},
           },
-          children: [2],
+          children: [2, 5],
         }, {
           _id: 2,
           id: {
             name: 'child',
             broccoliNode: true,
-            broccoliId: 1
+            broccoliId: 1,
+            broccoliCachedNode: false
           },
           stats: {
             own: {},
@@ -272,16 +285,45 @@ test('Builder', function (t) {
         }, {
           _id: 3,
           id: {
+            name: 'shared',
+            broccoliNode: true,
+            broccoliId: 2,
+            broccoliCachedNode: false
+          },
+          stats: {
+            own: {},
+            time: {},
+          },
+          children: [4],
+        }, {
+          _id: 4,
+          id: {
             name: 'srcDir',
             broccoliNode: true,
-            broccoliId: 2
+            broccoliId: 3,
+            broccoliCachedNode: false
           },
           stats: {
             own: {},
             time: {},
           },
           children: [],
-        }],
+        }, {
+          _id: 5,
+          id: {
+            name: 'shared',
+            broccoliNode: true,
+            broccoliId: 2,
+            broccoliCachedNode: true
+          },
+          stats: {
+            own: {},
+            time: {},
+          },
+          children: [],
+        }
+
+        ],
       })
       t.end()
     })

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -250,6 +250,7 @@ test('Builder', function (t) {
           id: {
             name: 'parent',
             broccoliNode: true,
+            broccoliId: 0
           },
           stats: {
             own: {},
@@ -261,6 +262,7 @@ test('Builder', function (t) {
           id: {
             name: 'child',
             broccoliNode: true,
+            broccoliId: 1
           },
           stats: {
             own: {},
@@ -272,6 +274,7 @@ test('Builder', function (t) {
           id: {
             name: 'srcDir',
             broccoliNode: true,
+            broccoliId: 2
           },
           stats: {
             own: {},


### PR DESCRIPTION
- [x] adds `heimdallNode.id.broccoliId`:
   * lets us disambiguate broccoli nodes across rebuilds
   * lets us have multiple heimdall nodes pointing to a single broccoli node
- [x] adds `heimdallNode.id.broccoliCachedNode`
   * lets us disambiguate heimdall nodes which represent only already read broccoli nodes.
- [x] also instrument the existence of cached broccoli nodes