### PR TITLE
Use `tree.annotation` if present.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -276,7 +276,8 @@ Node.prototype.toJSON = function() {
 
 exports.getDescription = getDescription
 function getDescription (tree) {
-  return (tree && tree.description) ||
+  return (tree && tree.annotation) ||
+    (tree && tree.description) ||
     (tree && tree.constructor && tree.constructor !== String && tree.constructor.name) ||
     ('' + tree)
 }

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -366,3 +366,58 @@ test('Builder', function (t) {
 
   t.end()
 })
+
+test('getDescription test', function(t) {
+  function FakeBaseNode() {}
+
+  test('annotation is used', function(t) {
+    var fakeNode = new FakeBaseNode();
+    fakeNode.annotation = 'fakeNode: boo';
+
+    var result = broccoli.getDescription(fakeNode);
+
+    t.equal(result, 'fakeNode: boo');
+    t.end();
+  });
+
+  test('description is used', function(t) {
+    var fakeNode = new FakeBaseNode();
+    fakeNode.description = 'fakeNode: boo';
+
+    var result = broccoli.getDescription(fakeNode);
+
+    t.equal(result, 'fakeNode: boo');
+    t.end();
+  });
+
+  test('annotation is used over description', function(t) {
+    var fakeNode = new FakeBaseNode();
+    fakeNode.annotation = 'fakeNode: boo';
+    fakeNode.description = 'fakeNode: who';
+
+    var result = broccoli.getDescription(fakeNode);
+
+    t.equal(result, 'fakeNode: boo');
+    t.end();
+  });
+
+  test('plugin name is used when no other description is present', function(t) {
+    var fakeNode = new FakeBaseNode();
+
+    var result = broccoli.getDescription(fakeNode);
+
+    t.equal(result, 'FakeBaseNode');
+    t.end();
+  });
+
+  test('string trees description is the path itself', function(t) {
+    var fakeNode = 'some/path/here/';
+
+    var result = broccoli.getDescription(fakeNode);
+
+    t.equal(result, 'some/path/here/');
+    t.end();
+  });
+
+  t.end();
+});


### PR DESCRIPTION
Newer versions of broccoli use `annotation` instead of `description` ([see broccoli-plugin](https://github.com/broccolijs/broccoli-plugin#reference) documentation).

Without including `annotation` in our `getDescription` code, we do not have the ability to see the proper descriptions for nodes based on broccoli-plugin that do not *also* add a `.description` (which some do manually).