### PR TITLE
Don't show BroccoliBuildError constructor itself in the stack trace

### DIFF
--- a/lib/broccoli-build-error.js
+++ b/lib/broccoli-build-error.js
@@ -37,7 +37,7 @@ function BroccoliBuildError(originalError, node) {
   this.broccoliPayload.error.location.file = originalError.file;
   this.broccoliPayload.error.location.treeDir = originalError.treeDir;
 
-  Error.captureStackTrace(this);
+  Error.captureStackTrace(this, BroccoliBuildError);
   this.message = 'Build Canceled: Broccoli Builder ran into an error with ' + node.info.name + ' plugin. 💥';
   // we need to set this flag to make sure builder does re-throw
   // and actually stops


### PR DESCRIPTION
cc @twokul 