### PR TITLE
Add line & column to broccoliPayload

### DIFF
--- a/lib/broccoli-build-error.js
+++ b/lib/broccoli-build-error.js
@@ -43,6 +43,14 @@ function BroccoliBuildError(originalError, node) {
   this.broccoliPayload.error.location.file = originalError.file;
   this.broccoliPayload.error.location.treeDir = originalError.treeDir;
 
+  var location = originalError.location || originalError.loc;
+  if (location) {
+    this.broccoliPayload.error.location = location;
+  } else {
+    this.broccoliPayload.error.location.line = originalError.line;
+    this.broccoliPayload.error.location.column = originalError.column;
+  }
+
   // we need to set this flag to make sure builder does re-throw
   // and actually stops
   this.wasCanceled = true;


### PR DESCRIPTION
This adds the line number and column for the `broccoliPayload.error.location`. Some plugins provide that information such as `broccoli-sass-source-maps`. 

Babel compiler error sends a `loc` object instead of `line` & `column` on the root as `broccoli-sass-source-maps`. The ember template compiler sends a object called `location` instead of `loc`. 

This change will help to get more useful information to users on error page and in console.