### PR TITLE
Don't break SilentError

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -160,6 +160,10 @@ Builder.prototype.build = function (willReadStringTree) {
               })
           })
         }).catch(function(e) {
+          if (typeof e === 'object' && e !== null && e.isSilentError) {
+            throw e;
+          }
+
           // because `readAndReturnNodeFor` is recursive
           // it does not make sense to throw multiple build errors,
           // we can just report a failure once.
@@ -168,9 +172,6 @@ Builder.prototype.build = function (willReadStringTree) {
             throw new BroccoliBuildError(e, node)
           }
 
-          if (typeof e === 'object' && e !== null && e.isSilentError) {
-            throw e;
-          }
           if (!hasMergedInstantiationStack) {
             e.stack = e.stack +  '\n\nThe broccoli plugin was instantiated at: \n' + tree._instantiationStack + '\n\n'
             e.message = 'The Broccoli Plugin: ' + tree + ' failed with:'

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -160,7 +160,7 @@ test('Builder', function (t) {
         builder.build().then(function () {
           t.equal(true, false, 'should not succeed')
         }).catch(function(reason) {
-          t.ok(reason.message.indexOf('Build Canceled: Broccoli Builder ran into an error with') !== -1)
+          t.ok(reason.message.indexOf('Build Canceled') !== -1)
 
           return cleaner.then(function() {
             t.equal(tree.cleanupCount, 1)


### PR DESCRIPTION
If a broccoli plugin throws SilentError, we wrap it in a BroccoliBuildError and lose its actual message, resulting in unhelpful output like:

```
Build failed.
The Broccoli Plugin: [BroccoliMergeTrees] failed with:
undefined

The broccoli plugin was instantiated at:
    at BroccoliMergeTrees.Plugin (/Users/edward/hacking/ember-cli-fastboot/node_modules/broccoli-plugin/index.js:7:31)
    at new BroccoliMergeTrees (/Users/edward/hacking/ember-cli-fastboot/node_modules/broccoli-merge-trees/index.js:16:10)
    at Class.postprocessTree (/Users/edward/hacking/ember-cli-fastboot/index.js:200:14)
    at projectOrAddon.addons.reduce (/Users/edward/hacking/cardstack-web/node_modules/ember-cli/lib/utilities/addon-process-tree.js:6:25)
    at Array.reduce (<anonymous>)
    at addonProcessTree (/Users/edward/hacking/cardstack-web/node_modules/ember-cli/lib/utilities/addon-process-tree.js:4:32)
    at EmberApp.addonPostprocessTree (/Users/edward/hacking/cardstack-web/node_modules/ember-cli/lib/broccoli/ember-app.js:600:12)
    at EmberApp.toTree (/Users/edward/hacking/cardstack-web/node_modules/ember-cli/lib/broccoli/ember-app.js:1716:17)
    at module.exports (/Users/edward/hacking/cardstack-web/ember-cli-build.js:50:14)
    at Builder.setupBroccoliBuilder (/Users/edward/hacking/cardstack-web/node_modules/ember-cli/lib/models/builder.js:56:19)
```

This change gives SilentError priority to be rethrown without being mangled.
```