### PR TITLE
Remove now defunct error message improving code.

### DIFF
--- a/lib/broccoli-build-error.js
+++ b/lib/broccoli-build-error.js
@@ -12,7 +12,8 @@ var path = require('path');
 
 module.exports = BroccoliBuildError;
 function BroccoliBuildError(originalError, node) {
-  var message = 'Build Canceled: Broccoli Builder ran into an error with ' + node.info.name + ' plugin. 💥\n' + originalError.message;
+  var name = node.info.name;
+  var message = 'Build Canceled: Broccoli Builder ran into an error with `' + name + '` plugin. 💥\n' + originalError.message;
   var error = Error.call(this, message);
   this.message = error.message;
   this.stack = originalError.stack;
@@ -28,7 +29,7 @@ function BroccoliBuildError(originalError, node) {
       node: process.version
     },
     broccoliNode: {
-      nodeName: node.info.name,
+      nodeName: name,
       nodeAnnotation: node.info.annotation,
       instantiationStack: node.info.instantiationStack || ''
     },

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -43,7 +43,6 @@ Builder.prototype.build = function (willReadStringTree) {
 
   var newTreesRead = []
   var nodeCache = []
-  var hasMergedInstantiationStack = false;
   this.isThrown = false;
 
   this._currentStep = RSVP.Promise.resolve()
@@ -172,11 +171,6 @@ Builder.prototype.build = function (willReadStringTree) {
             throw new BroccoliBuildError(e, node)
           }
 
-          if (!hasMergedInstantiationStack) {
-            e.stack = e.stack +  '\n\nThe broccoli plugin was instantiated at: \n' + tree._instantiationStack + '\n\n'
-            e.message = 'The Broccoli Plugin: ' + tree + ' failed with:'
-            hasMergedInstantiationStack = true
-          }
           throw e
         })
         .then(function (dir) {

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -86,7 +86,7 @@ test('Builder', function (t) {
         builder.build().then(function (hash) {
           t.equal(hash.directory, 'foo')
           builder.build().catch(function (err) {
-            t.equal(err.message, 'The Broccoli Plugin: [object Object] failed with:')
+            t.ok(/Build Canceled: Broccoli Builder ran into an error with `undefined` plugin./.test(err.message))
             return builder.cleanup()
           })
           .finally(function() {


### PR DESCRIPTION
It actually makes stuff worse, as the new BroccoliBuildError stuff handles this correctly.

Prior to this PR, we would end up with strange output. Where different errors would essentially get merged together, resulting in:

```
The Broccoli Plugin: [BroccoliMergeTrees: TreeMerger (appTestTrees)] failed with:
SyntaxError: dummy/tests/unit/services/service-worker-test.js: "setTimeout" is read-only
```

* an error from broccoli-babel-tranpiler
   * its stack is from broccoli-babel-tranpsiler
* claims to be from broccoli-merge-trees
  * its instantiation stack + message are from the wrapping broccoli-merge-trees

Now the error is:

```
Build Canceled: Broccoli Builder ran into an error with Babel plugin. 💥
dummy/tests/unit/services/service-worker-test.js: "setTimeout" is read-only
SyntaxError: dummy/tests/unit/services/service-worker-test.js: "setTimeout" is read-only
```