### PR TITLE
Remove BROCCOLI_WARN_READ_API env var and always warn on old .read/.rebuild api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.18.11
+
+* Remove BROCCOLI_WARN_READ_API environment variable, always output warnings for use of old `.read`/`.rebuild`
+api. Use broccoli-plugin instead: https://github.com/broccolijs/broccoli-plugin
+
 # 0.18.10
 
 * Ensure good error feedback when a `SilentError` is thrown.

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -233,8 +233,7 @@ Builder.prototype.wrapIfNecessary = function (tree) {
 }
 
 Builder.prototype.warnIfNecessary = function (tree) {
-  if (process.env.BROCCOLI_WARN_READ_API &&
-      (typeof tree.read === 'function' || typeof tree.rebuild === 'function') &&
+  if ((typeof tree.read === 'function' || typeof tree.rebuild === 'function') &&
       !tree.__broccoliFeatures__ &&
       !tree.suppressDeprecationWarning) {
     if (!this.didPrintWarningIntro) {


### PR DESCRIPTION
This API is no longer supported in the upstream master of Broccoli and has been deprecated for several years now.
Lets surface this error by default in ember cli asap so we can weed it out and not have to port it.