### PR TITLE
Use __broccoliGetInfo__() to get plugin/node name/label

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -288,6 +288,11 @@ Node.prototype.toJSON = function() {
 
 exports.getPluginName = getPluginName
 function getPluginName(tree) {
+  if (tree && tree.__broccoliGetInfo__) {
+    const info = tree.__broccoliGetInfo__();
+    return info.name;
+  }
+
   // string trees or plain POJO trees don't really have a plugin name
   if (!tree || tree.constructor === String || tree.constructor === Object) {
     return undefined;
@@ -297,6 +302,10 @@ function getPluginName(tree) {
 
 exports.getDescription = getDescription
 function getDescription (tree) {
+  if (tree && tree.__broccoliGetInfo__) {
+    const info = tree.__broccoliGetInfo__();
+    return info.annotation || info.name;
+  }
   return (tree && tree.annotation) ||
     (tree && tree.description) ||
     getPluginName(tree) ||


### PR DESCRIPTION
Using the `__broccoliGetInfo__()` allows the node name to be more descriptive, this includes annotations for anything that extends `broccoli-plugin` https://github.com/broccolijs/broccoli-plugin/blob/a41e4c9e2ea1b3b0cfbef17248c427aa3774e192/index.js#L55

E.g:

For a simple build:

![image](https://user-images.githubusercontent.com/1246671/40284535-79207786-5c5e-11e8-8501-35e8c61f7d71.png)

vs

![image](https://user-images.githubusercontent.com/1246671/40284529-72a7a33e-5c5e-11e8-9788-0c75917b0a9d.png)

or 

![image](https://user-images.githubusercontent.com/1246671/40284413-ffd3b4ac-5c5c-11e8-9393-58e00942e9bc.png)

vs the older:
![image](https://user-images.githubusercontent.com/1246671/40284419-0f5e5102-5c5d-11e8-86b8-8107b82a444d.png)

