### PR TITLE
Revert "Use __broccoliGetInfo__() to get plugin/node name/label"

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -287,11 +287,6 @@ Node.prototype.toJSON = function() {
 
 exports.getPluginName = getPluginName
 function getPluginName(tree) {
-  if (tree && tree.__broccoliGetInfo__) {
-    const info = tree.__broccoliGetInfo__();
-    return info.name;
-  }
-
   // string trees or plain POJO trees don't really have a plugin name
   if (!tree || tree.constructor === String || tree.constructor === Object) {
     return undefined;
@@ -301,10 +296,6 @@ function getPluginName(tree) {
 
 exports.getDescription = getDescription
 function getDescription (tree) {
-  if (tree && tree.__broccoliGetInfo__) {
-    const info = tree.__broccoliGetInfo__();
-    return info.annotation || info.name;
-  }
   return (tree && tree.annotation) ||
     (tree && tree.description) ||
     getPluginName(tree) ||


### PR DESCRIPTION
Reverts ember-cli/broccoli-builder#27

This is causing the following error:

```
Error: Minimum builderFeatures required: { persistentOutputFlag: true }
    at SRIHashAssets.Plugin._checkBuilderFeatures (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-caching-writer/node_modules/broccoli-plugin/index.js:62:11)
    at SRIHashAssets.Plugin.__broccoliGetInfo__ (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-caching-writer/node_modules/broccoli-plugin/index.js:45:8)
    at getPluginName (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/lib/builder.js:291:23)
    at new Node (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/lib/builder.js:260:11)
    at readAndReturnNodeFor (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/lib/builder.js:112:16)
    at /home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/lib/builder.js:52:14
    at tryCatch (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/node_modules/rsvp/dist/rsvp.js:525:12)
    at invokeCallback (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/node_modules/rsvp/dist/rsvp.js:538:13)
    at /home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/node_modules/rsvp/dist/rsvp.js:606:14
    at flush (/home/gitlab-runner/builds/12157f87/0/digitalization/personal_network_visualization/node_modules/broccoli-builder/node_modules/rsvp/dist/rsvp.js:2415:5)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

Reverting for now so that we can investigate more fully...