### PR TITLE
[do-not-merge] beta uber-cache

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -53,13 +53,29 @@ const UBER_CACHE = {
     'Concat: Vendor Styles/assets/vendor.css',
     'Funnel (styles)'
   ],
+  compiledHBSandJSTrees: [
+    'TreeMerger (preprocessedApp & templates)',
+    'Babel: frontend',
+    // 'Funnel (ember-cli-tree)',
+    'TreeMerger (appAndDependencies)',
+    'Concat App',
+    'Assembler (vendor & appJS)'
+  ],
   templatesTrees: [
     'TreeMerger (templates)',
     'ProcessedTemplateTree',
     'Funnel: Pod Templates'
   ],
+  jsTrees: [
+    'Funnel (config)',
+    'Funnel: Filtered App',
+    'TreeMerger (app)',
+    'ProcessedAppTree'
+  ],
   annotationTreesPaths: [
     'Addon#treeFor (ember-',
+    'Addon#treeFor (liquid-',
+    'Addon#treeForPublic',
     'Addon#treeForStyles',
     '#treeForVendor',
     'Addon#_addonTemplateFiles',
@@ -89,6 +105,8 @@ const UBER_CACHE = {
     (this.substrExistsInArray(annotation, this.annotationTreesPaths)
       || this.stylesTrees.includes(annotation)
       || this.templatesTrees.includes(annotation)
+      || this.jsTrees.includes(annotation)
+      || this.compiledHBSandJSTrees.includes(annotation)
     ) && (
       !this.substrExistsInArray(annotation, this.excludedAnnotationTreesPaths)
     )
@@ -123,15 +141,25 @@ const UBER_CACHE = {
   
     return [has, key];
   },
+  cleanJSCache() {
+    this.jsTrees.map(key=>{
+      this.leafCache.delete(key);
+    });
+  },
   cleanStylesCache() {
-    this.stylesTrees.map(stylePath=>{
-      this.leafCache.delete(stylePath);
+    this.stylesTrees.map(key=>{
+      this.leafCache.delete(key);
     });
   },
   cleanTemplatesCache() {
-    this.templatesTrees.map(stylePath=>{
-      this.leafCache.delete(stylePath);
+    this.templatesTrees.map(key=>{
+      this.leafCache.delete(key);
     })
+  },
+  cleanExtraCache() {
+    this.compiledHBSandJSTrees.map(key=>{
+      this.leafCache.delete(key);
+    });
   },
   cleanUp(changedFiles = []) {
     if (!changedFiles.length) {
@@ -143,12 +171,21 @@ const UBER_CACHE = {
     let hasChangedTemplates = changedFiles.filter(file=>{
       return file.includes('.hbs');
     }).length;
+    let hasChangedScripts = changedFiles.filter(file=>{
+      return file.includes('.js');
+    }).length;
   
+    if (hasChangedScripts) {
+      this.cleanJSCache();
+    }
     if (hasChangedStyles) {
       this.cleanStylesCache();
     }
     if (hasChangedTemplates) {
       this.cleanTemplatesCache();
+    }
+    if (hasChangedScripts || hasChangedTemplates) {
+      this.cleanExtraCache();
     }
   },
   getItemFromCache(subtree) {
@@ -157,7 +194,6 @@ const UBER_CACHE = {
     }
     let [has, key] = this.hasCachableAnnotation(subtree);
     if (has && this.leafCache.has(key)) {
-      console.log('fromCache', key);
       return this.leafCache.get(key);
     } else {
       // console.log(subtree);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -4,8 +4,6 @@ var apiCompat = require('./api_compat')
 var heimdall = require('heimdalljs');
 var SilentError = require('silent-error');
 var BroccoliBuildError = require('./broccoli-build-error');
-var getNodeInfo = require('broccoli-node-info').getNodeInfo;
-var InvalidNodeError = require('broccoli-node-info').InvalidNodeError;
 
 exports.Builder = Builder
 function Builder (tree) {
@@ -37,14 +35,173 @@ function summarize(node) {
 
 RSVP.EventTarget.mixin(Builder.prototype)
 
-Builder.prototype.build = function (willReadStringTree) {
+
+const UBER_CACHE = {
+  buildType: 'initial',
+  substrExistsInArray(str, arr) {
+    let size = arr.length;
+    for (let i = 0; i < size; i++) {
+      if (str.includes(arr[i])) {
+        return true;
+      }
+    }
+    return false;
+  },
+  leafCache: new Map(),
+  stylesTrees: [
+    'styles',
+    'Concat: Vendor Styles/assets/vendor.css',
+    'Funnel (styles)'
+  ],
+  templatesTrees: [
+    'TreeMerger (templates)',
+    'ProcessedTemplateTree',
+    'Funnel: Pod Templates'
+  ],
+  annotationTreesPaths: [
+    'Addon#treeFor (ember-',
+    'Addon#treeForStyles',
+    '#treeForVendor',
+    'Addon#_addonTemplateFiles',
+    'Addon#compileAddon',
+    'addonPreprocessTree(template)',
+    'Babel: ember-',
+    'Babel: @ember-',
+    'Funnel: addon-tree-output',
+    'Babel: moment',
+    "TreeMerger: `addon/` trees",
+    "TreeMerger: (vendor)",
+    "Funnel (vendor)",
+    'Vendor JS',
+    'Babel: liquid-',
+    'Creator math/',
+    'Creator ember-'
+  ],
+  excludedAnnotationTreesPaths: ['Babel: ember-data'],
+  directoryTrees: ['ember-','node_modules','ember/','moment'],
+  hasCachableAnnotation(subtree) {
+    let annotation = subtree._annotation;
+    let destDir = subtree.destDir;
+    let name = subtree.name;
+    let key = annotation;
+
+    let has =  annotation && 
+    (this.substrExistsInArray(annotation, this.annotationTreesPaths)
+      || this.stylesTrees.includes(annotation)
+      || this.templatesTrees.includes(annotation)
+    ) && (
+      !this.substrExistsInArray(annotation, this.excludedAnnotationTreesPaths)
+    )
+  
+    if (!has && annotation && annotation.includes('TreeMerger (custom transform:')) {
+      has = true;
+      key = annotation + subtree.outputPath;
+    }
+  
+    if (!has && annotation && annotation.includes('TreeMerger (ExternalTree)')) {
+      has = true;
+      key = annotation + subtree.outputPath;
+    }
+  
+    if (!has && name === 'UnwatchedDir') {
+      has = true;
+      key = name + subtree._directoryPath;
+    }
+  
+    if (!has && name && destDir) {
+      has = this.substrExistsInArray(destDir, this.directoryTrees);
+  
+      if (has) {
+        key = name + destDir;
+      }
+    }
+  
+    if (!has && name && name === 'broccoli-persistent-filter:ReplaceFilter' && subtree.files && subtree.files.length) {
+      has = true;
+      key = name + subtree.files.join(':');
+    }
+  
+    return [has, key];
+  },
+  cleanStylesCache() {
+    this.stylesTrees.map(stylePath=>{
+      this.leafCache.delete(stylePath);
+    });
+  },
+  cleanTemplatesCache() {
+    this.templatesTrees.map(stylePath=>{
+      this.leafCache.delete(stylePath);
+    })
+  },
+  cleanUp(changedFiles = []) {
+    if (!changedFiles.length) {
+      return;
+    }
+    let hasChangedStyles = changedFiles.filter(file=>{
+      return file.includes('.scss') || file.includes('.css');
+    }).length;
+    let hasChangedTemplates = changedFiles.filter(file=>{
+      return file.includes('.hbs');
+    }).length;
+  
+    if (hasChangedStyles) {
+      this.cleanStylesCache();
+    }
+    if (hasChangedTemplates) {
+      this.cleanTemplatesCache();
+    }
+  },
+  getItemFromCache(subtree) {
+    if (this.isFirstBuild()) {
+      return false;
+    }
+    let [has, key] = this.hasCachableAnnotation(subtree);
+    if (has && this.leafCache.has(key)) {
+      console.log('fromCache', key);
+      return this.leafCache.get(key);
+    } else {
+      // console.log(subtree);
+      // console.log('-------------');
+    }
+    return false;
+  },
+  addItemToCache(subtree, childNode) {
+    if (this.isFirstBuild()) {
+      return false;
+    }
+    let [hasItem, itemKey] = this.hasCachableAnnotation(subtree);
+    if (hasItem) {
+      this.leafCache.set(itemKey, childNode);
+    } else {
+      if (subtree._annotation) {
+        console.log(subtree._annotation);
+      }
+    }
+  },
+  isFirstBuild() {
+    return this.buildType === 'initial';
+  },
+  setStrategy({changedFiles, type}) {
+    this.buildType = type;
+    if (!this.isFirstBuild()) {
+      this.cleanUp(changedFiles);
+    }
+  }
+}
+
+Builder.prototype.build = function (willReadStringTree, resultAnnotation) {
+
   if (this.canceled) {
     return RSVP.Promise.reject(new Error('cannot build this builder, as it has been previously canceled'));
   }
+
+  UBER_CACHE.setStrategy(resultAnnotation);
+
   var builder = this
 
   var newTreesRead = []
   var nodeCache = []
+  var hasMergedInstantiationStack = false;
   this.isThrown = false;
 
   this._currentStep = RSVP.Promise.resolve()
@@ -80,13 +237,14 @@ Builder.prototype.build = function (willReadStringTree) {
   // Read the `tree` and return its node, which in particular contains the
   // tree's output directory (node.directory)
   function readAndReturnNodeFor (tree) {
+    
     if (builder.canceled) {
       var canceled = new SilentError('Build Canceled');
       canceled.wasCanceled = true
       return RSVP.Promise.reject(canceled);
     }
 
-
+    // console.log('readAndReturnNodeFor', tree._directoryPath);
     builder.warnIfNecessary(tree)
     tree = builder.wrapIfNecessary(tree)
     var index = newTreesRead.indexOf(tree)
@@ -146,6 +304,13 @@ Builder.prototype.build = function (willReadStringTree) {
             if (readTreeRunning) {
               throw new Error('Parallel readTree call detected; read trees in sequence, e.g. using https://github.com/joliss/promise-map-series')
             }
+
+            let cachedItem = UBER_CACHE.getItemFromCache(subtree);
+            if (cachedItem) {
+              node.addChild(cachedItem);
+              return cachedItem.directory;
+            }
+
             readTreeRunning = true
 
             return RSVP.Promise.resolve()
@@ -153,6 +318,9 @@ Builder.prototype.build = function (willReadStringTree) {
                 return readAndReturnNodeFor(subtree) // recurse
               })
               .then(function (childNode) {
+               
+                UBER_CACHE.addItemToCache(subtree, childNode);
+                
                 node.addChild(childNode)
                 return childNode.directory
               })
@@ -173,6 +341,11 @@ Builder.prototype.build = function (willReadStringTree) {
             throw new BroccoliBuildError(e, node)
           }
 
+          if (!hasMergedInstantiationStack) {
+            e.stack = e.stack +  '\n\nThe broccoli plugin was instantiated at: \n' + tree._instantiationStack + '\n\n'
+            e.message = 'The Broccoli Plugin: ' + tree + ' failed with:'
+            hasMergedInstantiationStack = true
+          }
           throw e
         })
         .then(function (dir) {
@@ -223,6 +396,7 @@ Builder.prototype.cleanup = function () {
 
 Builder.prototype.wrapIfNecessary = function (tree) {
   if (typeof tree.rebuild === 'function') {
+    console.log('tree.rebuild', tree);
     // Note: We wrap even if the plugin provides a `.read` function, so that
     // its new `.rebuild` function gets called.
     if (!tree.wrappedTree) { // memoize
@@ -235,7 +409,8 @@ Builder.prototype.wrapIfNecessary = function (tree) {
 }
 
 Builder.prototype.warnIfNecessary = function (tree) {
-  if ((typeof tree.read === 'function' || typeof tree.rebuild === 'function') &&
+  if (process.env.BROCCOLI_WARN_READ_API &&
+      (typeof tree.read === 'function' || typeof tree.rebuild === 'function') &&
       !tree.__broccoliFeatures__ &&
       !tree.suppressDeprecationWarning) {
     if (!this.didPrintWarningIntro) {
@@ -289,17 +464,6 @@ Node.prototype.toJSON = function() {
 
 exports.getPluginName = getPluginName
 function getPluginName(tree) {
-  if (typeof tree !== 'string') {
-    try {
-      const info = getNodeInfo(tree);
-      return info.name;
-    } catch (e) {
-      if (!e instanceof InvalidNodeError) {
-        throw e;
-      }
-    }
-  }
-
   // string trees or plain POJO trees don't really have a plugin name
   if (!tree || tree.constructor === String || tree.constructor === Object) {
     return undefined;
@@ -309,16 +473,6 @@ function getPluginName(tree) {
 
 exports.getDescription = getDescription
 function getDescription (tree) {
-  if (typeof tree !== 'string') {
-    try {
-      const info = getNodeInfo(tree);
-      return info.annotation || info.name;
-    } catch (e) {
-      if (!e instanceof InvalidNodeError) {
-        throw e;
-      }
-    }
-  }
   return (tree && tree.annotation) ||
     (tree && tree.description) ||
     getPluginName(tree) ||

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -139,6 +139,10 @@ const UBER_CACHE = {
       key = name + subtree.files.join(':');
     }
   
+     if (String(key).toLowerCase().includes('test')) {
+      return [false, key];
+    }
+
     return [has, key];
   },
   cleanJSCache() {


### PR DESCRIPTION
Windows **Rebuild**  times _3-4x_ faster! (hooky caching)

**Cache will work after second rebuild!**
-----------------------------------------------------
* Go to `node_modules/ember-cli/lib/models/builder.js`
replace
```js
.then(() => this.builder.build(willReadStringDir))
```
 to
```js
.then(() => this.builder.build(willReadStringDir, resultAnnotation))
```
https://github.com/ember-cli/ember-cli/pull/7891/files (PR)

-----------------------------------------------------
* Go to `node_modules/broccoli-builder/lib/builder.js`

take `UBER_CACHE` object from this PR and add it after this code

```js
RSVP.EventTarget.mixin(Builder.prototype)
```

find
```js
Builder.prototype.build = function (willReadStringTree)
```
replace to
```js
Builder.prototype.build = function (willReadStringTree, resultAnnotation)
```

and before 
```js
  var builder = this

  var newTreesRead = []
  var nodeCache = []
  this.isThrown = false;
``` 

add 
```js
UBER_CACHE.setStrategy(resultAnnotation);
```

and before 
```js
readTreeRunning = true
```

add

```js
let cachedItem = UBER_CACHE.getItemFromCache(subtree);
            if (cachedItem) {
           node.addChild(cachedItem);
           return cachedItem.directory;
         }
```

and after 
```js
.then(function (childNode)
``` 
add 

```js
UBER_CACHE.addItemToCache(subtree, childNode);
```

``
done! Second rebuild gonna be faster 3x times!